### PR TITLE
feat [#7] : Entity에서 사용하는 공통 Auditable delete 부분 추가 (예시 작성)

### DIFF
--- a/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/basket/entity/Basket.java
+++ b/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/basket/entity/Basket.java
@@ -8,10 +8,14 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE basket SET deleted = true WHERE id = ?")
+@Where(clause = "deleted = false")
 public class Basket extends Auditable {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/freshgreenish/src/main/java/com/sidenow/freshgreenish/global/utils/Auditable.java
+++ b/freshgreenish/src/main/java/com/sidenow/freshgreenish/global/utils/Auditable.java
@@ -23,6 +23,8 @@ public abstract class Auditable {
     @LastModifiedDate
     private LocalDateTime lastModifiedAt;
 
+    private boolean deleted;
+
     protected Auditable() {
         this.createdAt = LocalDateTime.now();
         this.lastModifiedAt = LocalDateTime.now();


### PR DESCRIPTION
- 각 Entity에 사용할 공통 Auditable 삭제 여부를 개발 진행 전에 이런식으로 다른 Entity에 추가하려고 합니다.
- 저는 이렇게 생각해서 개발했습니다. 혹시 다른 의견 있으시면 말씀해주세요.


