### PR TITLE
과일 판매/리뷰/좋아요/문의 Service 및 Repository 생성

### DIFF
--- a/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/answer/repository/AnswerRepository.java
+++ b/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/answer/repository/AnswerRepository.java
@@ -1,0 +1,7 @@
+package com.sidenow.freshgreenish.domain.answer.repository;
+
+import com.sidenow.freshgreenish.domain.answer.entity.Answer;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AnswerRepository extends JpaRepository<Answer, Long>, CustomAnswerRepository {
+}

--- a/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/answer/repository/AnswerRepositoryImpl.java
+++ b/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/answer/repository/AnswerRepositoryImpl.java
@@ -1,0 +1,15 @@
+package com.sidenow.freshgreenish.domain.answer.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class AnswerRepositoryImpl implements CustomAnswerRepository{
+    private final JPAQueryFactory queryFactory;
+
+    public AnswerRepositoryImpl(EntityManager em) {
+        this.queryFactory = new JPAQueryFactory(em);
+    }
+
+}

--- a/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/answer/repository/CustomAnswerRepository.java
+++ b/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/answer/repository/CustomAnswerRepository.java
@@ -1,0 +1,4 @@
+package com.sidenow.freshgreenish.domain.answer.repository;
+
+public interface CustomAnswerRepository {
+}

--- a/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/answer/service/AnswerDbService.java
+++ b/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/answer/service/AnswerDbService.java
@@ -1,0 +1,16 @@
+package com.sidenow.freshgreenish.domain.answer.service;
+
+import com.sidenow.freshgreenish.domain.answer.entity.Answer;
+import com.sidenow.freshgreenish.domain.answer.repository.AnswerRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AnswerDbService {
+    private final AnswerRepository answerRepository;
+
+    public void saveAnswer(Answer answer) {
+        answerRepository.save(answer);
+    }
+}

--- a/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/answer/service/AnswerService.java
+++ b/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/answer/service/AnswerService.java
@@ -1,0 +1,11 @@
+package com.sidenow.freshgreenish.domain.answer.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AnswerService {
+}

--- a/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/likes/entity/Likes.java
+++ b/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/likes/entity/Likes.java
@@ -12,8 +12,6 @@ import org.hibernate.annotations.Where;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@SQLDelete(sql = "UPDATE likes SET deleted = true WHERE id = ?")
-@Where(clause = "deleted = false")
 public class Likes {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/likes/repository/CustomLikesRepository.java
+++ b/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/likes/repository/CustomLikesRepository.java
@@ -1,0 +1,4 @@
+package com.sidenow.freshgreenish.domain.likes.repository;
+
+public interface CustomLikesRepository {
+}

--- a/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/likes/repository/LikesRepository.java
+++ b/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/likes/repository/LikesRepository.java
@@ -1,0 +1,7 @@
+package com.sidenow.freshgreenish.domain.likes.repository;
+
+import com.sidenow.freshgreenish.domain.likes.entity.Likes;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LikesRepository extends JpaRepository<Likes, Long>, CustomLikesRepository {
+}

--- a/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/likes/repository/LikesRepositoryImpl.java
+++ b/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/likes/repository/LikesRepositoryImpl.java
@@ -1,0 +1,15 @@
+package com.sidenow.freshgreenish.domain.likes.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class LikesRepositoryImpl implements CustomLikesRepository {
+    private final JPAQueryFactory queryFactory;
+
+    public LikesRepositoryImpl(EntityManager em) {
+        this.queryFactory = new JPAQueryFactory(em);
+    }
+
+}

--- a/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/likes/service/LikesService.java
+++ b/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/likes/service/LikesService.java
@@ -1,0 +1,13 @@
+package com.sidenow.freshgreenish.domain.likes.service;
+
+import com.sidenow.freshgreenish.domain.likes.repository.LikesRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class LikesService {
+    private final LikesRepository likesRepository;
+}

--- a/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/product/entity/ProductImage.java
+++ b/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/product/entity/ProductImage.java
@@ -13,8 +13,6 @@ import org.hibernate.annotations.Where;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@SQLDelete(sql = "UPDATE product_image SET deleted = true WHERE id = ?")
-@Where(clause = "deleted = false")
 public class ProductImage {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/product/repository/CustomProductRepository.java
+++ b/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/product/repository/CustomProductRepository.java
@@ -1,0 +1,4 @@
+package com.sidenow.freshgreenish.domain.product.repository;
+
+public interface CustomProductRepository {
+}

--- a/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/product/repository/ProductRepository.java
+++ b/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/product/repository/ProductRepository.java
@@ -1,0 +1,7 @@
+package com.sidenow.freshgreenish.domain.product.repository;
+
+import com.sidenow.freshgreenish.domain.product.entity.Product;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProductRepository extends JpaRepository<Product, Long>, CustomProductRepository {
+}

--- a/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/product/repository/ProductRepositoryImpl.java
+++ b/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/product/repository/ProductRepositoryImpl.java
@@ -1,0 +1,15 @@
+package com.sidenow.freshgreenish.domain.product.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class ProductRepositoryImpl implements CustomProductRepository {
+    private final JPAQueryFactory queryFactory;
+
+    public ProductRepositoryImpl(EntityManager em) {
+        this.queryFactory = new JPAQueryFactory(em);
+    }
+
+}

--- a/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/product/service/ProductDbService.java
+++ b/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/product/service/ProductDbService.java
@@ -1,0 +1,16 @@
+package com.sidenow.freshgreenish.domain.product.service;
+
+import com.sidenow.freshgreenish.domain.product.entity.Product;
+import com.sidenow.freshgreenish.domain.product.repository.ProductRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ProductDbService {
+    private final ProductRepository productRepository;
+
+    public void saveProduct(Product product) {
+        productRepository.save(product);
+    }
+}

--- a/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/product/service/ProductService.java
+++ b/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/product/service/ProductService.java
@@ -1,0 +1,12 @@
+package com.sidenow.freshgreenish.domain.product.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ProductService {
+    private final ProductDbService productDbService;
+}

--- a/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/question/repository/CustomQuestionRepository.java
+++ b/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/question/repository/CustomQuestionRepository.java
@@ -1,0 +1,4 @@
+package com.sidenow.freshgreenish.domain.question.repository;
+
+public interface CustomQuestionRepository {
+}

--- a/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/question/repository/QuestionRepository.java
+++ b/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/question/repository/QuestionRepository.java
@@ -1,0 +1,7 @@
+package com.sidenow.freshgreenish.domain.question.repository;
+
+import com.sidenow.freshgreenish.domain.question.entity.Question;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface QuestionRepository extends JpaRepository<Question, Long>, CustomQuestionRepository {
+}

--- a/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/question/repository/QuestionRepositoryImpl.java
+++ b/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/question/repository/QuestionRepositoryImpl.java
@@ -1,0 +1,15 @@
+package com.sidenow.freshgreenish.domain.question.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class QuestionRepositoryImpl implements CustomQuestionRepository {
+    private final JPAQueryFactory queryFactory;
+
+    public QuestionRepositoryImpl(EntityManager em) {
+        this.queryFactory = new JPAQueryFactory(em);
+    }
+
+}

--- a/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/question/service/QuestionDbService.java
+++ b/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/question/service/QuestionDbService.java
@@ -1,0 +1,16 @@
+package com.sidenow.freshgreenish.domain.question.service;
+
+import com.sidenow.freshgreenish.domain.question.entity.Question;
+import com.sidenow.freshgreenish.domain.question.repository.QuestionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class QuestionDbService {
+    private final QuestionRepository questionRepository;
+
+    public void saveQuestion(Question question) {
+        questionRepository.save(question);
+    }
+}

--- a/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/question/service/QuestionService.java
+++ b/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/question/service/QuestionService.java
@@ -1,0 +1,13 @@
+package com.sidenow.freshgreenish.domain.question.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class QuestionService {
+    private final QuestionDbService questionDbService;
+
+}

--- a/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/review/entity/ReviewImage.java
+++ b/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/review/entity/ReviewImage.java
@@ -13,8 +13,6 @@ import org.hibernate.annotations.Where;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@SQLDelete(sql = "UPDATE review_image SET deleted = true WHERE id = ?")
-@Where(clause = "deleted = false")
 public class ReviewImage {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/review/entity/ReviewLikes.java
+++ b/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/review/entity/ReviewLikes.java
@@ -12,8 +12,6 @@ import org.hibernate.annotations.Where;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@SQLDelete(sql = "UPDATE review_likes SET deleted = true WHERE id = ?")
-@Where(clause = "deleted = false")
 public class ReviewLikes {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/review/repository/CustomReviewRepository.java
+++ b/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/review/repository/CustomReviewRepository.java
@@ -1,0 +1,4 @@
+package com.sidenow.freshgreenish.domain.review.repository;
+
+public interface CustomReviewRepository {
+}

--- a/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/review/repository/ReviewRepository.java
+++ b/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/review/repository/ReviewRepository.java
@@ -1,0 +1,7 @@
+package com.sidenow.freshgreenish.domain.review.repository;
+
+import com.sidenow.freshgreenish.domain.review.entity.Review;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReviewRepository extends JpaRepository<Review, Long>, CustomReviewRepository {
+}

--- a/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/review/repository/ReviewRepositoryImpl.java
+++ b/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/review/repository/ReviewRepositoryImpl.java
@@ -1,0 +1,15 @@
+package com.sidenow.freshgreenish.domain.review.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class ReviewRepositoryImpl implements CustomReviewRepository {
+    private final JPAQueryFactory queryFactory;
+
+    public ReviewRepositoryImpl(EntityManager em) {
+        this.queryFactory = new JPAQueryFactory(em);
+    }
+
+}

--- a/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/review/service/ReviewDbService.java
+++ b/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/review/service/ReviewDbService.java
@@ -1,0 +1,16 @@
+package com.sidenow.freshgreenish.domain.review.service;
+
+import com.sidenow.freshgreenish.domain.review.entity.Review;
+import com.sidenow.freshgreenish.domain.review.repository.ReviewRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ReviewDbService {
+    private final ReviewRepository reviewRepository;
+
+    public void saveReview(Review review) {
+        reviewRepository.save(review);
+    }
+}

--- a/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/review/service/ReviewService.java
+++ b/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/review/service/ReviewService.java
@@ -1,0 +1,12 @@
+package com.sidenow.freshgreenish.domain.review.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ReviewService {
+    private final ReviewDbService reviewDbService;
+}


### PR DESCRIPTION
# Description
과일 판매/리뷰/좋아요/문의 Service 및 Repository 생성

Auditable 상속받지 않는 Likes, ProductImage, ReviewImage, ReviewLikes Entity에 있는 아래 코드는 삭제했습니다.

```

@SQLDelete(sql = "UPDATE review_likes SET deleted = true WHERE id = ?")
@Where(clause = "deleted = false")

```

또한 Service와 Repository를 생성하였는데, QueryDSL 사용을 위해 RepositoryImpl Class 파일과 CustomRepository Interface 파일을 추가하였습니다.
DbService의 경우에는 Likes를 제외하고는 Save와 같이 Repository에 관련된 코드들은 DbService에 작성하고 Service에서는 DbService를 주입받아 사용하고자 생성하였습니다.

# TODO
1. Product
- [X] ProductService
- [X] ProductDbService
- [X] ProductRepository
- [X] ProductRepositoryImpl
- [X] CustomProductRepository


2. Review
- [X] ReviewService
- [X] ReviewDbService
- [X] ReviewRepository
- [X] ReviewRepositoryImpl
- [X] CustomReviewRepository


3. Likes
- [X] LikesService
- [X] LikesRepository
- [X] LikesRepositoryImpl
- [X] CustomLikesRepository


4. Question
- [X] QuestionService
- [X] QuestionDbService
- [X] QuestionRepository
- [X] QuestionRepositoryImpl
- [X] CustomQuestionRepository


5. Answer
- [X] AnswerService
- [X] AnswerDbService
- [X] AnswerRepository
- [X] AnswerRepositoryImpl
- [X] CustomAnswerRepository


6. Entity
- [X] Likes
- [X] ProductImage
- [X] ReviewImage
- [X] ReviewLikes


# ETC
기타사항
