### PR TITLE
kakao 결제 기능 구현 - 단건 결제, 장바구니 결제

### DIFF
--- a/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/basket/repository/BasketRepositoryImpl.java
+++ b/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/basket/repository/BasketRepositoryImpl.java
@@ -73,4 +73,13 @@ public class BasketRepositoryImpl implements CustomBasketRepository {
                         .and(productBasket.product.productId.eq(productId)))
                 .fetchOne();
     }
+
+    @Override
+    public List<Long> getProductIdInBasket(Long basketId) {
+        return queryFactory
+                .select(product.productId)
+                .from(productBasket)
+                .where(productBasket.basket.basketId.eq(basketId))
+                .fetch();
+    }
 }

--- a/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/basket/repository/CustomBasketRepository.java
+++ b/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/basket/repository/CustomBasketRepository.java
@@ -4,8 +4,12 @@ import com.sidenow.freshgreenish.domain.basket.dto.GetBasket;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
+
 public interface CustomBasketRepository {
     Page<GetBasket> getBasketList(Long userId, Pageable pageable);
+
+    List<Long> getProductIdInBasket(Long basketId);
 
     Integer getTotalBasketPrice(Long basketId);
     Integer getDiscountedTotalBasketPrice(Long basketId);

--- a/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/basket/service/BasketDbService.java
+++ b/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/basket/service/BasketDbService.java
@@ -36,6 +36,9 @@ public class BasketDbService {
 
         return Basket.builder()
                 .userId(userId)
+                .totalBasketPrice(0)
+                .discountedBasketPrice(0)
+                .discountedBasketTotalPrice(0)
                 .build();
     }
 
@@ -60,6 +63,10 @@ public class BasketDbService {
 
     public Page<GetBasket> getBasketList(Long userId, Pageable pageable) {
         return basketRepository.getBasketList(userId, pageable);
+    }
+
+    public List<Long> getProductIdInBasket(Long basketId) {
+        return basketRepository.getProductIdInBasket(basketId);
     }
 
     public Integer getTotalBasketPrice(Long basketId) {

--- a/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/payment/controller/PaymentController.java
+++ b/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/payment/controller/PaymentController.java
@@ -8,6 +8,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 
+import static com.sidenow.freshgreenish.domain.purchase.util.PurchaseConstants.CANCELED_PAY_MESSAGE;
 import static com.sidenow.freshgreenish.domain.purchase.util.PurchaseConstants.FAILED_PAY_MESSAGE;
 
 @RestController
@@ -24,6 +25,14 @@ public class PaymentController {
         return ResponseEntity.ok().body(message);
     }
 
+    // kakao 결제 요청
+    @GetMapping("/purchase/{purchaseId}/kakao/payment")
+    public ResponseEntity<Message<?>> orderKakaoPayment(@PathVariable("purchaseId") Long purchaseId) {
+        Message<?> message = paymentService.getKaKaoPayUrl(purchaseId);
+        if (message.getData() == null) paymentService.getFailedPayMessage();
+        return ResponseEntity.ok().body(message);
+    }
+
     // Toss 결제 성공
     @GetMapping("/api/purchase/{purchaseId}/toss/success")
     public ResponseEntity<Message<?>> successTossPayment(@PathVariable("purchaseId") Long purchaseId) {
@@ -32,9 +41,30 @@ public class PaymentController {
         return ResponseEntity.ok().build();
     }
 
+    // kakao 결제 성공
+    @GetMapping("/api/purchase/{purchaseId}/kakao/success")
+    public ResponseEntity<Message<?>> successKakaoPayment(@PathVariable("purchaseId") Long purchaseId,
+                                                          @RequestParam("pg_token") String pgToken) {
+        Message<?> message = paymentService.getSuccessKakaoPaymentInfo(purchaseId, pgToken);
+        if (message.getData() == null) paymentService.getFailedPayMessage();
+        return ResponseEntity.ok().build();
+    }
+
     // Toss 결제 실패
     @GetMapping("/api/purchase/{purchaseId}/toss/failure")
     public ResponseEntity<String> failedTossPayment(@PathVariable("purchaseId") Long purchaseId) {
+        return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).body(FAILED_PAY_MESSAGE);
+    }
+
+    // kakao 결제 취소
+    @GetMapping("/api/purchase/{purchaseId}/kakao/cancellation")
+    public ResponseEntity<String> cancelKakaoPayment(@PathVariable("purchaseId") Long purchaseId) {
+        return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).body(CANCELED_PAY_MESSAGE);
+    }
+
+    // kakao 결제 실패
+    @GetMapping("/api/purchase/{purchaseId}/kakao/failure")
+    public ResponseEntity<String> failedKakaoPayment(@PathVariable("purchaseId") Long purchaseId) {
         return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).body(FAILED_PAY_MESSAGE);
     }
 

--- a/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/payment/entity/PaymentInfo.java
+++ b/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/payment/entity/PaymentInfo.java
@@ -1,6 +1,7 @@
 package com.sidenow.freshgreenish.domain.payment.entity;
 
 import com.fasterxml.jackson.annotation.JsonManagedReference;
+import com.sidenow.freshgreenish.domain.payment.kakao.ReadyToKakaoPayInfo;
 import com.sidenow.freshgreenish.domain.payment.toss.ReadyToTossPayInfo;
 import com.sidenow.freshgreenish.domain.purchase.entity.Purchase;
 import jakarta.persistence.*;
@@ -14,6 +15,8 @@ public class PaymentInfo {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "PAYMENT_ID")
     private Long paymentId;
+
+    private Integer quantity = 0;
 
     /* ---------- 카카오 ---------- */
 
@@ -66,6 +69,21 @@ public class PaymentInfo {
         this.orderId = body.getOrderId();
         this.orderName = body.getOrderName();
         this.successUrl = body.getSuccessUrl();
+    }
+
+    public void setKakaoPaymentInfo(ReadyToKakaoPayInfo params, String tid) {
+        this.cid = params.getCid();
+        this.tid = tid;
+        this.partnerOrderId = params.getPartner_order_id();
+        this.partnerUserId = params.getPartner_user_id();
+        this.itemName = params.getItem_name();
+        this.quantity = params.getQuantity();
+        this.totalAmount = params.getTotal_amount();
+        this.valAmount = params.getVal_amount();
+        this.taxFreeAmount = params.getTax_free_amount();
+        this.approvalUrl = params.getApproval_url();
+        this.failUrl = params.getFail_url();
+        this.cancelUrl = params.getCancel_url();
     }
 }
 

--- a/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/payment/feign/KakaoPayFeignClient.java
+++ b/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/payment/feign/KakaoPayFeignClient.java
@@ -1,0 +1,30 @@
+package com.sidenow.freshgreenish.domain.payment.feign;
+
+import com.sidenow.freshgreenish.domain.payment.kakao.*;
+import com.sidenow.freshgreenish.domain.payment.util.PayConstants;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.cloud.openfeign.SpringQueryMap;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+@FeignClient(value = "kakaopay", url = "https://kapi.kakao.com", configuration = {FeignErrorConfig.class})
+public interface KakaoPayFeignClient {
+    @PostMapping(value = "/v1/payment/ready")
+    KakaoPayReadyInfo readyForPayment(@RequestHeader(PayConstants.AUTHORIZATION) String authorization,
+                                      @RequestHeader(PayConstants.ACCEPT) String accept,
+                                      @RequestHeader(PayConstants.CONTENT_TYPE) String contentType,
+                                      @SpringQueryMap ReadyToKakaoPayInfo params);
+
+    @PostMapping(value = "/v1/payment/approve")
+    KakaoPaySuccessInfo successForPayment(
+            @RequestHeader(PayConstants.AUTHORIZATION) String authorization,
+            @RequestHeader(PayConstants.ACCEPT) String accept,
+            @RequestHeader(PayConstants.CONTENT_TYPE) String contentType,
+            @SpringQueryMap RequestForKakaoPayInfo query);
+
+    @PostMapping(value = "/v1/payment/cancel")
+    KakaoPayCancelInfo cancelForPayment(@RequestHeader(PayConstants.AUTHORIZATION) String authorization,
+                                        @RequestHeader(PayConstants.ACCEPT) String accept,
+                                        @RequestHeader(PayConstants.CONTENT_TYPE) String contentType,
+                                        @SpringQueryMap RequestForKakaoPayCancelInfo params);
+}

--- a/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/payment/kakao/Amount.java
+++ b/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/payment/kakao/Amount.java
@@ -1,0 +1,21 @@
+package com.sidenow.freshgreenish.domain.payment.kakao;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class Amount {
+    private Integer total;
+    private Integer taxFree;
+    private Integer vat;
+    private Integer point;
+    private Integer discount;
+}

--- a/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/payment/kakao/ApprovedCancelAmount.java
+++ b/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/payment/kakao/ApprovedCancelAmount.java
@@ -1,0 +1,15 @@
+package com.sidenow.freshgreenish.domain.payment.kakao;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ApprovedCancelAmount {
+    private Integer total;
+    private Integer vat;
+}

--- a/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/payment/kakao/CancelAvailableAmount.java
+++ b/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/payment/kakao/CancelAvailableAmount.java
@@ -1,0 +1,14 @@
+package com.sidenow.freshgreenish.domain.payment.kakao;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CancelAvailableAmount {
+    private Integer total;
+}

--- a/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/payment/kakao/CanceledAmount.java
+++ b/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/payment/kakao/CanceledAmount.java
@@ -1,0 +1,15 @@
+package com.sidenow.freshgreenish.domain.payment.kakao;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CanceledAmount {
+    private Integer total;
+    private Integer vat;
+}

--- a/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/payment/kakao/KakaoCard.java
+++ b/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/payment/kakao/KakaoCard.java
@@ -1,0 +1,27 @@
+package com.sidenow.freshgreenish.domain.payment.kakao;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class KakaoCard {
+    private String purchaseCorp;
+    private String purchaseCorpCode;
+    private String issuerCorp;
+    private String issuerCorpCode;
+    private String bin;
+    private String cardType;
+    private String installMonth;
+    private String approvedId;
+    private String cardMid;
+    private String interestFreeInstall;
+    private String cardItemCode;
+}

--- a/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/payment/kakao/KakaoPayCancelInfo.java
+++ b/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/payment/kakao/KakaoPayCancelInfo.java
@@ -1,0 +1,40 @@
+package com.sidenow.freshgreenish.domain.payment.kakao;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class KakaoPayCancelInfo {
+    private String aid;
+    private String tid;
+    private String cid;
+    private String status;
+    private String partnerOrderId;
+    private String partnerUserId;
+    private String paymentMethodType;
+    private Amount amount;
+    private ApprovedCancelAmount approvedCancelAmount;
+    private CanceledAmount canceledAmount;
+    private CancelAvailableAmount cancelAvailableAmount;
+    private String itemName;
+    private String itemCode;
+    private Integer quantity;
+    private Date createdAt;
+    private Date approvedAt;
+    private Date canceledAt;
+    private String orderStatus;
+
+    public void setOrderStatus(String orderStatus) {
+        this.orderStatus = orderStatus;
+    }
+}

--- a/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/payment/kakao/KakaoPayHeader.java
+++ b/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/payment/kakao/KakaoPayHeader.java
@@ -1,0 +1,16 @@
+package com.sidenow.freshgreenish.domain.payment.kakao;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class KakaoPayHeader {
+    private String accept;
+    private String adminKey;
+    private String contentType;
+}

--- a/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/payment/kakao/KakaoPayReadyInfo.java
+++ b/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/payment/kakao/KakaoPayReadyInfo.java
@@ -1,0 +1,27 @@
+package com.sidenow.freshgreenish.domain.payment.kakao;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class KakaoPayReadyInfo {
+    private String partnerOrderId;
+    private String partnerUserId;
+    private String itemName;
+    private Integer quantity;
+    private Integer totalAmount;
+    private Integer taxFreeAmount;
+    private String tid;
+    private String nextRedirectPcUrl;
+    private Date createdAt;
+}

--- a/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/payment/kakao/KakaoPaySuccessInfo.java
+++ b/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/payment/kakao/KakaoPaySuccessInfo.java
@@ -1,0 +1,40 @@
+package com.sidenow.freshgreenish.domain.payment.kakao;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class KakaoPaySuccessInfo {
+    private String aid;
+    private String tid;
+    private String cid;
+    private String sid;
+    private String partnerOrderId;
+    private String partnerUserId;
+    private String paymentMethodType;
+    private Amount amount;
+    private KakaoCard kakaoCard;
+    private String itemName;
+    private String itemCode;
+    private String payload;
+    private Integer quantity;
+    private Integer taxFreeAmount;
+    private Integer vatAmount;
+    private Date createdAt;
+    private Date approvedAt;
+    private String orderStatus;
+
+    public void setOrderStatus(String orderStatus) {
+        this.orderStatus = orderStatus;
+    }
+}

--- a/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/payment/kakao/ReadyToKakaoPayInfo.java
+++ b/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/payment/kakao/ReadyToKakaoPayInfo.java
@@ -1,0 +1,24 @@
+package com.sidenow.freshgreenish.domain.payment.kakao;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReadyToKakaoPayInfo {
+    private String cid;
+    private String partner_order_id;
+    private String partner_user_id;
+    private String item_name;
+    private Integer quantity;
+    private Integer total_amount;
+    private Integer val_amount;
+    private Integer tax_free_amount;
+    private String approval_url;
+    private String fail_url;
+    private String cancel_url;
+}

--- a/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/payment/kakao/RequestForKakaoPayCancelInfo.java
+++ b/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/payment/kakao/RequestForKakaoPayCancelInfo.java
@@ -1,0 +1,17 @@
+package com.sidenow.freshgreenish.domain.payment.kakao;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RequestForKakaoPayCancelInfo {
+    private String cid;
+    private String tid;
+    private Integer cancel_amount;
+    private Integer cancel_tax_free_amount;
+}

--- a/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/payment/kakao/RequestForKakaoPayInfo.java
+++ b/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/payment/kakao/RequestForKakaoPayInfo.java
@@ -1,0 +1,19 @@
+package com.sidenow.freshgreenish.domain.payment.kakao;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RequestForKakaoPayInfo {
+    private String cid;
+    private String tid;
+    private String pg_token;
+    private Integer total_amount;
+    private String partner_user_id;
+    private String partner_order_id;
+}

--- a/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/purchase/entity/Purchase.java
+++ b/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/purchase/entity/Purchase.java
@@ -22,10 +22,15 @@ public class Purchase extends Auditable {
     @Column(name = "PURCHASE_ID")
     private Long purchaseId;
     private Long userId;
+
+    @Setter
     private Long addressId;
 
     @Setter
     private String purchaseNumber;
+
+    @Setter
+    private Integer totalCount;
 
     // 다건 결제
     private Long basketId;
@@ -59,14 +64,16 @@ public class Purchase extends Auditable {
     private List<ProductPurchase> productPurchase = new ArrayList<>();
 
     @Builder
-    public Purchase(Long purchaseId, Long basketId, Long userId, Long addressId, Long productId, Integer count,
-                    Integer totalPrice, Boolean isRegularDelivery, Integer totalPriceBeforeUsePoint, Integer usedPoints) {
+    public Purchase(Long purchaseId, Long basketId, Long userId, Long addressId, Long productId,
+                    Integer count, Integer totalCount, Integer totalPrice, Boolean isRegularDelivery,
+                    Integer totalPriceBeforeUsePoint, Integer usedPoints) {
         this.purchaseId = purchaseId;
         this.basketId = basketId;
         this.userId = userId;
         this.addressId = addressId;
         this.productId = productId;
         this.count = count;
+        this.totalCount = totalCount;
         this.totalPrice = totalPrice;
         this.isRegularDelivery = isRegularDelivery;
         this.totalPriceBeforeUsePoint = totalPriceBeforeUsePoint;

--- a/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/purchase/service/PurchaseService.java
+++ b/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/purchase/service/PurchaseService.java
@@ -43,6 +43,7 @@ public class PurchaseService {
                 .addressId(1L) // 수정 예정
                 .usedPoints(0)
                 .count(post.getCount())
+                .totalCount(post.getCount())
                 .isRegularDelivery(false)
                 .totalPrice(productDbService.getPrice(productId) * post.getCount())
                 .totalPriceBeforeUsePoint(productDbService.getPrice(productId) * post.getCount())
@@ -79,6 +80,7 @@ public class PurchaseService {
                 .addressId(1L) // 수정 예정
                 .usedPoints(0)
                 .count(1)
+                .totalCount(1)
                 .isRegularDelivery(false)
                 .build();
 


### PR DESCRIPTION
# Description
카카오페이 결제 구현 및 조회 - 단건 결제, 장바구니 결제

```
요약
카카오페이 결제 구현 및 조회 기능 구현
```

<br/>

디테일한 부분들은 계속해서 수정이 필요하지만 1차 카카오페이 결제 기능 구현했습니다.
1. 상품페이지 단건 결제
2. 장바구니 선택 결제
3. 장바구니 전체 결제

장바구니에 있는 상품을 구매하면 장바구니에서 삭제하는 기능은 구현 완료하였으며,
이후 배송지를 입력 하는 등의 기능이 추가로 구현되어야 할 것 같습니다.

# ETC


<br/>
