### PR TITLE
정기 결제 기능 구현 및 장바구니 기능 수정, 그외 코드 추가 및 정리

### DIFF
--- a/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/address/controller/AddressController.java
+++ b/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/address/controller/AddressController.java
@@ -4,45 +4,70 @@ import com.sidenow.freshgreenish.domain.address.dto.GetAddressDTO;
 import com.sidenow.freshgreenish.domain.address.dto.PostAddressDTO;
 import com.sidenow.freshgreenish.domain.address.service.AddressService;
 import com.sidenow.freshgreenish.domain.dto.SingleResponseDto;
+import com.sidenow.freshgreenish.domain.purchase.dto.AddressInfo;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.core.user.OAuth2User;
-import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-public class AddressController{
+public class AddressController {
     private final AddressService addressService;
 
-
     @GetMapping("/mypage/address")
-    public ResponseEntity getAddress(@AuthenticationPrincipal OAuth2User oauth){
+    public ResponseEntity getAddress(@AuthenticationPrincipal OAuth2User oauth) {
         List<GetAddressDTO> dtos = addressService.readAddress(oauth);
         return ResponseEntity.ok(dtos);
     }
 
-
     @PostMapping("/mypage/address/create")
-    public ResponseEntity postAddress(@AuthenticationPrincipal OAuth2User oauth, @RequestBody PostAddressDTO dto) {
+    public ResponseEntity postAddress(@AuthenticationPrincipal OAuth2User oauth,
+                                      @RequestBody PostAddressDTO dto) {
         Boolean isInMyPage = true;
         addressService.createAddress(oauth, dto, isInMyPage);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
     @PatchMapping("/mypage/address/update")
-    public ResponseEntity patchAddress(@AuthenticationPrincipal OAuth2User oauth, @RequestParam("addressId") Long addressId, @RequestBody PostAddressDTO dto){
+    public ResponseEntity patchAddress(@AuthenticationPrincipal OAuth2User oauth,
+                                       @RequestParam("addressId") Long addressId,
+                                       @RequestBody PostAddressDTO dto) {
         addressService.updateAddress(oauth, addressId, dto);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
     @DeleteMapping("/mypage/address/delete")
-    public ResponseEntity deleteAddress(@RequestParam("addressId") Long addressId){
+    public ResponseEntity deleteAddress(@RequestParam("addressId") Long addressId) {
         addressService.deleteAddress(addressId);
         return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @PostMapping("/purchase/{purchaseId}/address/create")
+    public ResponseEntity createAddressForPurchase(@PathVariable("purchaseId") Long purchaseId,
+                                                   @RequestBody @Valid PostAddressDTO post,
+                                                   @AuthenticationPrincipal OAuth2User oauth) {
+        addressService.addAddressForPurchase(oauth, purchaseId, post);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/purchase/{purchaseId}/address/{addressId}")
+    public ResponseEntity getAddressIdForPurchase(@PathVariable("purchaseId") Long purchaseId,
+                                                  @PathVariable("addressId") Long addressId,
+                                                  @AuthenticationPrincipal OAuth2User oauth) {
+        addressService.addAddressIdForPurchase(oauth, purchaseId, addressId);
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/purchase/{purchaseId}/address")
+    public ResponseEntity getAddressForPurchase(@PathVariable("purchaseId") Long purchaseId,
+                                                @AuthenticationPrincipal OAuth2User oauth) {
+        AddressInfo address = addressService.getAddressForPurchase(oauth, purchaseId);
+        return ResponseEntity.ok().body(new SingleResponseDto<>(address));
     }
 }

--- a/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/address/service/AddressDbService.java
+++ b/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/address/service/AddressDbService.java
@@ -1,0 +1,37 @@
+package com.sidenow.freshgreenish.domain.address.service;
+
+import com.sidenow.freshgreenish.domain.address.entity.Address;
+import com.sidenow.freshgreenish.domain.address.repository.AddressRepository;
+import com.sidenow.freshgreenish.domain.purchase.service.PurchaseDbService;
+import com.sidenow.freshgreenish.domain.user.service.UserDbService;
+import com.sidenow.freshgreenish.global.exception.BusinessLogicException;
+import com.sidenow.freshgreenish.global.exception.ExceptionCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class AddressDbService {
+    private final AddressRepository addressRepository;
+    private final UserDbService userDbService;
+    private final PurchaseDbService purchaseDbService;
+
+    public void saveAddress(Address address) {
+        addressRepository.save(address);
+    }
+
+    public Address saveAndReturnAddress(Address address) {
+        return addressRepository.save(address);
+    }
+
+    public Address ifExistsReturnAddress(Long addressId) {
+        return addressRepository.findById(addressId)
+                .orElseThrow(() -> new BusinessLogicException(ExceptionCode.ADDRESS_NOT_FOUND));
+    }
+
+    public Optional<Address> ifExistsReturnOptionalAddress(Long addressId) {
+        return addressRepository.findById(addressId);
+    }
+}

--- a/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/basket/controller/BasketController.java
+++ b/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/basket/controller/BasketController.java
@@ -1,14 +1,16 @@
 package com.sidenow.freshgreenish.domain.basket.controller;
 
 import com.sidenow.freshgreenish.domain.basket.dto.*;
-import com.sidenow.freshgreenish.domain.basket.service.BasketDbService;
 import com.sidenow.freshgreenish.domain.basket.service.BasketService;
+import com.sidenow.freshgreenish.domain.user.service.UserDbService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -16,36 +18,41 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/basket")
 public class BasketController {
     private final BasketService basketService;
-    private final BasketDbService basketDbService;
+    private final UserDbService userDbService;
 
-    @PostMapping("/product/{productId}")
+    @PostMapping("/product/{productId}/{type}")
     public ResponseEntity addProductInBasket(@PathVariable("productId") Long productId,
-                                             @RequestBody @Valid PostBasket post) {
-        Long userId = 1L;
-        basketService.addProductInBasket(productId, userId, post);
+                                             @PathVariable("type") String type,
+                                             @RequestBody @Valid PostBasket post,
+                                             @AuthenticationPrincipal OAuth2User oauth) {
+        basketService.addProductInBasket(productId, oauth, post, type);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
-    @PatchMapping("/product/{productId}")
+    @PatchMapping("/product/{productId}/{type}")
     public ResponseEntity changeProductCountInBasket(@PathVariable("productId") Long productId,
-                                                     @RequestBody @Valid PostBasket post) {
-        Long userId = 1L;
-        basketService.changeProductCountInBasket(userId, productId, post);
+                                                     @PathVariable("type") String type,
+                                                     @RequestBody @Valid PostBasket post,
+                                                     @AuthenticationPrincipal OAuth2User oauth) {
+        basketService.changeProductCountInBasket(oauth, productId, post, type);
         return ResponseEntity.ok().build();
     }
 
-    @GetMapping()
-    public ResponseEntity getBasketList(Pageable pageable) {
-        Long userId = 1L;
-        Page<GetBasket> basket = basketDbService.getBasketList(userId, pageable);
-        TotalPriceInfo info = basketService.getTotalPriceInfo(userId);
+    @GetMapping("/{type}")
+    public ResponseEntity getBasketList(Pageable pageable,
+                                        @PathVariable("type") String type,
+                                        @AuthenticationPrincipal OAuth2User oauth) {
+        Page<GetBasket> basket = basketService.getBasketList(oauth, pageable, type);
+        TotalPriceInfo info = basketService.getTotalPriceInfo(oauth, type);
         return ResponseEntity.ok().body(new WrapBasket<>(basket, info));
     }
 
-    @DeleteMapping()
-    public ResponseEntity deleteProductInBasket(@RequestBody @Valid DeleteBasket delete) {
-        Long userId = 1L;
-        basketService.deleteProductInBasket(userId, delete);
+
+    @DeleteMapping("/{type}")
+    public ResponseEntity deleteProductInBasket(@RequestBody @Valid DeleteBasket delete,
+                                                @PathVariable("type") String type,
+                                                @AuthenticationPrincipal OAuth2User oauth) {
+        basketService.deleteBasket(oauth, delete, type);
         return ResponseEntity.ok().build();
     }
 }

--- a/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/basket/entity/Basket.java
+++ b/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/basket/entity/Basket.java
@@ -22,17 +22,26 @@ public class Basket{
     private Integer discountedBasketTotalPrice;
     private Integer discountedBasketPrice;
 
+    private Integer totalRegularPrice;
+    private Integer discountedRegularTotalPrice;
+    private Integer discountedRegularPrice;
+
     @JsonManagedReference
     @OneToMany(mappedBy = "basket", cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
     private List<ProductBasket> productBasket = new ArrayList<>();
 
     @Builder
-    public Basket(Long basketId, Long userId, Integer totalBasketPrice, Integer discountedBasketTotalPrice, Integer discountedBasketPrice) {
+    public Basket(Long basketId, Long userId, Integer totalBasketPrice, Integer discountedBasketTotalPrice,
+                  Integer discountedBasketPrice, Integer totalRegularPrice, Integer discountedRegularTotalPrice,
+                  Integer discountedRegularPrice) {
         this.basketId = basketId;
         this.userId = userId;
         this.totalBasketPrice = totalBasketPrice;
         this.discountedBasketTotalPrice = discountedBasketTotalPrice;
         this.discountedBasketPrice = discountedBasketPrice;
+        this.totalRegularPrice = totalRegularPrice;
+        this.discountedRegularTotalPrice = discountedRegularTotalPrice;
+        this.discountedRegularPrice = discountedRegularPrice;
     }
 
     public void setBasketPrice(Integer totalBasketPrice, Integer discountedBasketTotalPrice, Integer discountedBasketPrice) {
@@ -41,13 +50,15 @@ public class Basket{
         this.discountedBasketTotalPrice = discountedBasketTotalPrice;
     }
 
+    public void setRegularPrice(Integer totalRegularPrice, Integer discountedRegularTotalPrice,
+                                Integer discountedRegularPrice) {
+        this.totalRegularPrice = totalRegularPrice;
+        this.discountedRegularTotalPrice = discountedRegularTotalPrice;
+        this.discountedRegularPrice = discountedRegularPrice;
+    }
+
     public void addProductBasket(ProductBasket productBaskets) {
         if(productBaskets.getBasket() != this) productBaskets.addBasket(this);
         productBasket.add(productBaskets);
-    }
-
-    public void editProductImage(List<ProductBasket> productBaskets) {
-        this.productBasket.clear();
-        this.productBasket.addAll(productBaskets);
     }
 }

--- a/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/basket/entity/ProductBasket.java
+++ b/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/basket/entity/ProductBasket.java
@@ -7,21 +7,17 @@ import lombok.*;
 
 @Entity
 @Getter
+@Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ProductBasket{
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "PRODUCT_BASKET_ID")
     private Long productBasketId;
-
-    @Setter
     private Integer count;
-
-    @Setter
     private Integer totalPrice = 0;
-
-    @Setter
     private Integer discountedTotalPrice = 0;
+    private Boolean isRegular = false;
 
     @JsonBackReference
     @ManyToOne(fetch = FetchType.LAZY)
@@ -34,11 +30,13 @@ public class ProductBasket{
     private Basket basket;
 
     @Builder
-    public ProductBasket(Long productBasketId, Integer count, Integer totalPrice, Integer discountedTotalPrice) {
+    public ProductBasket(Long productBasketId, Integer count, Integer totalPrice,
+                         Integer discountedTotalPrice, Boolean isRegular) {
         this.productBasketId = productBasketId;
         this.count = count;
         this.totalPrice = totalPrice;
         this.discountedTotalPrice = discountedTotalPrice;
+        this.isRegular = isRegular;
     }
 
     public void addProduct(Product product) {

--- a/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/basket/repository/BasketRepositoryImpl.java
+++ b/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/basket/repository/BasketRepositoryImpl.java
@@ -36,7 +36,33 @@ public class BasketRepositoryImpl implements CustomBasketRepository {
                         product.discountPrice
                 )).from(productBasket)
                 .leftJoin(product).on(product.productId.eq(productBasket.product.productId))
-                .where(productBasket.basket.userId.eq(userId))
+                .where(productBasket.basket.userId.eq(userId)
+                        .and(productBasket.isRegular.eq(false)))
+                .orderBy(productBasket.productBasketId.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        long total = results.size();
+        return new PageImpl<>(results, pageable, total);
+    }
+
+    @Override
+    public Page<GetBasket> getRegularList(Long userId, Pageable pageable) {
+        List<GetBasket> results = queryFactory.select(
+                        new QGetBasket(
+                                productBasket.productBasketId,
+                                product.productId,
+                                product.title,
+                                product.productFirstImage,
+                                productBasket.count,
+                                product.price,
+                                product.discountRate,
+                                product.discountPrice
+                        )).from(productBasket)
+                .leftJoin(product).on(product.productId.eq(productBasket.product.productId))
+                .where(productBasket.basket.userId.eq(userId)
+                        .and(productBasket.isRegular.eq(true)))
                 .orderBy(productBasket.productBasketId.desc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
@@ -51,7 +77,18 @@ public class BasketRepositoryImpl implements CustomBasketRepository {
         return queryFactory
                 .select(productBasket.totalPrice.sum())
                 .from(productBasket)
-                .where(productBasket.basket.basketId.eq(basketId))
+                .where(productBasket.basket.basketId.eq(basketId)
+                        .and(productBasket.isRegular.eq(false)))
+                .fetchOne();
+    }
+
+    @Override
+    public Integer getTotalRegularPrice(Long basketId) {
+        return queryFactory
+                .select(productBasket.totalPrice.sum())
+                .from(productBasket)
+                .where(productBasket.basket.basketId.eq(basketId)
+                        .and(productBasket.isRegular.eq(true)))
                 .fetchOne();
     }
 
@@ -60,7 +97,18 @@ public class BasketRepositoryImpl implements CustomBasketRepository {
         return queryFactory
                 .select(productBasket.discountedTotalPrice.sum())
                 .from(productBasket)
-                .where(productBasket.basket.basketId.eq(basketId))
+                .where(productBasket.basket.basketId.eq(basketId)
+                        .and(productBasket.isRegular.eq(false)))
+                .fetchOne();
+    }
+
+    @Override
+    public Integer getDiscountedTotalRegularPrice(Long basketId) {
+        return queryFactory
+                .select(productBasket.discountedTotalPrice.sum())
+                .from(productBasket)
+                .where(productBasket.basket.basketId.eq(basketId)
+                        .and(productBasket.isRegular.eq(true)))
                 .fetchOne();
     }
 
@@ -70,16 +118,39 @@ public class BasketRepositoryImpl implements CustomBasketRepository {
                 .select(productBasket.discountedTotalPrice)
                 .from(productBasket)
                 .where(productBasket.basket.basketId.eq(basketId)
-                        .and(productBasket.product.productId.eq(productId)))
+                        .and(productBasket.product.productId.eq(productId))
+                        .and(productBasket.isRegular.eq(false)))
+                .fetchOne();
+    }
+
+    @Override
+    public Integer getProductPriceInRegular(Long productId, Long basketId) {
+        return queryFactory
+                .select(productBasket.discountedTotalPrice)
+                .from(productBasket)
+                .where(productBasket.basket.basketId.eq(basketId)
+                        .and(productBasket.product.productId.eq(productId))
+                        .and(productBasket.isRegular.eq(true)))
                 .fetchOne();
     }
 
     @Override
     public List<Long> getProductIdInBasket(Long basketId) {
         return queryFactory
-                .select(product.productId)
+                .select(productBasket.product.productId)
                 .from(productBasket)
-                .where(productBasket.basket.basketId.eq(basketId))
+                .where(productBasket.basket.basketId.eq(basketId)
+                        .and(productBasket.isRegular.eq(false)))
+                .fetch();
+    }
+
+    @Override
+    public List<Long> getProductIdInRegular(Long basketId) {
+        return queryFactory
+                .select(productBasket.product.productId)
+                .from(productBasket)
+                .where(productBasket.basket.basketId.eq(basketId)
+                        .and(productBasket.isRegular.eq(true)))
                 .fetch();
     }
 }

--- a/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/basket/repository/CustomBasketRepository.java
+++ b/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/basket/repository/CustomBasketRepository.java
@@ -8,11 +8,16 @@ import java.util.List;
 
 public interface CustomBasketRepository {
     Page<GetBasket> getBasketList(Long userId, Pageable pageable);
+    Page<GetBasket> getRegularList(Long userId, Pageable pageable);
 
     List<Long> getProductIdInBasket(Long basketId);
+    List<Long> getProductIdInRegular(Long basketId);
 
     Integer getTotalBasketPrice(Long basketId);
+    Integer getTotalRegularPrice(Long basketId);
     Integer getDiscountedTotalBasketPrice(Long basketId);
+    Integer getDiscountedTotalRegularPrice(Long basketId);
 
     Integer getProductPriceInBasket(Long productId, Long basketId);
+    Integer getProductPriceInRegular(Long productId, Long basketId);
 }

--- a/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/basket/repository/ProductBasketRepository.java
+++ b/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/basket/repository/ProductBasketRepository.java
@@ -7,4 +7,5 @@ import java.util.Optional;
 
 public interface ProductBasketRepository extends JpaRepository<ProductBasket, Long> {
     Optional<ProductBasket> findByProductProductIdAndBasketBasketId(Long productId, Long basketId);
+    Optional<ProductBasket> findByProductProductIdAndBasketBasketIdAndIsRegular(Long productId, Long basketId, Boolean isRegular);
 }

--- a/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/basket/service/BasketDbService.java
+++ b/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/basket/service/BasketDbService.java
@@ -39,6 +39,9 @@ public class BasketDbService {
                 .totalBasketPrice(0)
                 .discountedBasketPrice(0)
                 .discountedBasketTotalPrice(0)
+                .totalRegularPrice(0)
+                .discountedRegularTotalPrice(0)
+                .discountedRegularPrice(0)
                 .build();
     }
 
@@ -57,28 +60,57 @@ public class BasketDbService {
                 .orElseThrow(() -> new BusinessLogicException(ExceptionCode.PRODUCT_BASKET_NOT_FOUND));
     }
 
+    public ProductBasket ifExistsReturnProductBasketByIsRegular(Long productId, Long basketId, Boolean isRegular) {
+        return productBasketRepository.findByProductProductIdAndBasketBasketIdAndIsRegular(productId, basketId, isRegular)
+                .orElseThrow(() -> new BusinessLogicException(ExceptionCode.PRODUCT_BASKET_NOT_FOUND));
+    }
+
     public Optional<ProductBasket> ifExistFindByProductIdAndBasketId(Long productId, Long basketId) {
         return productBasketRepository.findByProductProductIdAndBasketBasketId(productId, basketId);
+    }
+
+    public Optional<ProductBasket> ifExistFindByProductIdAndBasketIdAndIdRegular(Long productId, Long basketId, Boolean isRegular) {
+        return productBasketRepository.findByProductProductIdAndBasketBasketIdAndIsRegular(productId, basketId, isRegular);
     }
 
     public Page<GetBasket> getBasketList(Long userId, Pageable pageable) {
         return basketRepository.getBasketList(userId, pageable);
     }
 
+    public Page<GetBasket> getRegularList(Long userId, Pageable pageable) {
+        return basketRepository.getRegularList(userId, pageable);
+    }
+
     public List<Long> getProductIdInBasket(Long basketId) {
         return basketRepository.getProductIdInBasket(basketId);
+    }
+
+    public List<Long> getProductIdInRegular(Long basketId) {
+        return basketRepository.getProductIdInRegular(basketId);
     }
 
     public Integer getTotalBasketPrice(Long basketId) {
         return basketRepository.getTotalBasketPrice(basketId);
     }
 
+    public Integer getTotalRegularPrice(Long basketId) {
+        return basketRepository.getTotalRegularPrice(basketId);
+    }
+
     public Integer getDiscountedTotalBasketPrice(Long basketId) {
         return basketRepository.getDiscountedTotalBasketPrice(basketId);
     }
 
+    public Integer getDiscountedTotalRegularPrice(Long basketId) {
+        return basketRepository.getDiscountedTotalRegularPrice(basketId);
+    }
+
     public Integer getProductPriceInBasket(Long productId, Long basketId) {
         return basketRepository.getProductPriceInBasket(productId, basketId);
+    }
+
+    public Integer getProductPriceInRegular(Long productId, Long basketId) {
+        return basketRepository.getProductPriceInRegular(productId, basketId);
     }
 
     public void deleteAllByProductBasketId(List<Long> productBasketId) {

--- a/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/basket/service/BasketService.java
+++ b/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/basket/service/BasketService.java
@@ -1,14 +1,19 @@
 package com.sidenow.freshgreenish.domain.basket.service;
 
 import com.sidenow.freshgreenish.domain.basket.dto.DeleteBasket;
+import com.sidenow.freshgreenish.domain.basket.dto.GetBasket;
 import com.sidenow.freshgreenish.domain.basket.dto.PostBasket;
 import com.sidenow.freshgreenish.domain.basket.dto.TotalPriceInfo;
 import com.sidenow.freshgreenish.domain.basket.entity.Basket;
 import com.sidenow.freshgreenish.domain.basket.entity.ProductBasket;
 import com.sidenow.freshgreenish.domain.product.entity.Product;
 import com.sidenow.freshgreenish.domain.product.service.ProductDbService;
+import com.sidenow.freshgreenish.domain.user.service.UserDbService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -20,50 +25,111 @@ import java.util.Optional;
 public class BasketService {
     private final BasketDbService basketDbService;
     private final ProductDbService productDbService;
+    private final UserDbService userDbService;
 
-    public void addProductInBasket(Long productId, Long userId, PostBasket post) {
-        Basket findBasket = basketDbService.ifExistsReturnBasket(userId);
+    public void addProductInBasket(Long productId, OAuth2User oauth, PostBasket post, String type) {
+        Basket findBasket = basketDbService.ifExistsReturnBasket(userDbService.findUserIdByOauth(oauth));
         Product findProduct = productDbService.ifExistsReturnProduct(productId);
+
+        switch (type) {
+            case "regular":
+                addProductRegularBasket(productId, findBasket, post, findProduct);
+                break;
+            default:
+                addProductBasket(productId, findBasket, post, findProduct);
+        }
+
+        productDbService.saveProduct(findProduct);
+    }
+
+    private void addProductBasket(Long productId, Basket basket, PostBasket post, Product product) {
         Optional<ProductBasket> findProductBasket =
-                basketDbService.ifExistFindByProductIdAndBasketId(productId, findBasket.getBasketId());
+                basketDbService.ifExistFindByProductIdAndBasketIdAndIdRegular(productId, basket.getBasketId(), false);
 
         if (findProductBasket.isPresent()) {
             Integer originalCount = findProductBasket.get().getCount();
             Integer totalCount = originalCount + post.getCount();
 
+            findProductBasket.get().setIsRegular(false);
             findProductBasket.get().setCount(totalCount);
-            findProductBasket.get().setTotalPrice(totalCount * findProduct.getPrice());
-            findProductBasket.get().setDiscountedTotalPrice(totalCount * findProduct.getDiscountPrice());
+            findProductBasket.get().setTotalPrice(totalCount * product.getPrice());
+            findProductBasket.get().setDiscountedTotalPrice(totalCount * product.getDiscountPrice());
 
-            findBasket.addProductBasket(findProductBasket.get());
+            basket.addProductBasket(findProductBasket.get());
 
-            findProductBasket.get().addBasket(findBasket);
-            findProductBasket.get().addProduct(findProduct);
+            findProductBasket.get().addBasket(basket);
+            findProductBasket.get().addProduct(product);
         } else {
             ProductBasket productBasket = ProductBasket.builder()
-                .count(post.getCount())
-                .totalPrice(findProduct.getPrice() * post.getCount())
-                .discountedTotalPrice(findProduct.getDiscountPrice() * post.getCount())
-                .build();
+                    .isRegular(false)
+                    .count(post.getCount())
+                    .totalPrice(product.getPrice() * post.getCount())
+                    .discountedTotalPrice(product.getDiscountPrice() * post.getCount())
+                    .build();
 
-            findBasket.addProductBasket(productBasket);
+            basket.addProductBasket(productBasket);
 
-            productBasket.addBasket(findBasket);
-            productBasket.addProduct(findProduct);
+            productBasket.addBasket(basket);
+            productBasket.addProduct(product);
         }
-        productDbService.saveProduct(findProduct);
 
-        Basket newBasket = basketDbService.saveAndReturnBasket(findBasket);
-
+        Basket newBasket = basketDbService.saveAndReturnBasket(basket);
         calculateTotalPrice(newBasket);
 
         basketDbService.saveBasket(newBasket);
     }
 
-    public void changeProductCountInBasket(Long userId, Long productId, PostBasket post) {
-        Basket findBasket = basketDbService.ifExistsReturnBasketByUserId(userId);
-        ProductBasket findProductBasket =
-                basketDbService.ifExistsReturnProductBasket(productId, findBasket.getBasketId());
+    private void addProductRegularBasket(Long productId, Basket basket, PostBasket post, Product product) {
+        Optional<ProductBasket> findProductBasket =
+                basketDbService.ifExistFindByProductIdAndBasketIdAndIdRegular(productId, basket.getBasketId(), true);
+
+        if (findProductBasket.isPresent()) {
+            Integer originalCount = findProductBasket.get().getCount();
+            Integer totalCount = originalCount + post.getCount();
+
+            findProductBasket.get().setIsRegular(true);
+            findProductBasket.get().setCount(totalCount);
+            findProductBasket.get().setTotalPrice(totalCount * product.getPrice());
+            findProductBasket.get().setDiscountedTotalPrice(totalCount * product.getDiscountPrice());
+
+            basket.addProductBasket(findProductBasket.get());
+
+            findProductBasket.get().addBasket(basket);
+            findProductBasket.get().addProduct(product);
+        } else {
+            ProductBasket productBasket = ProductBasket.builder()
+                    .isRegular(true)
+                    .count(post.getCount())
+                    .totalPrice(product.getPrice() * post.getCount())
+                    .discountedTotalPrice(product.getDiscountPrice() * post.getCount())
+                    .build();
+
+            basket.addProductBasket(productBasket);
+
+            productBasket.addBasket(basket);
+            productBasket.addProduct(product);
+        }
+
+        Basket newBasket = basketDbService.saveAndReturnBasket(basket);
+        calculateRegularTotalPrice(newBasket);
+
+        basketDbService.saveBasket(newBasket);
+    }
+
+    public void changeProductCountInBasket(OAuth2User oauth, Long productId, PostBasket post, String type) {
+        Basket findBasket = basketDbService.ifExistsReturnBasketByUserId(userDbService.findUserIdByOauth(oauth));
+
+        ProductBasket findProductBasket;
+
+        switch (type) {
+            case "regular":
+                findProductBasket =
+                        basketDbService.ifExistsReturnProductBasketByIsRegular(productId, findBasket.getBasketId(), true);
+                break;
+            default:
+                findProductBasket =
+                        basketDbService.ifExistsReturnProductBasketByIsRegular(productId, findBasket.getBasketId(), false);
+        }
 
         Integer count = post.getCount();
 
@@ -80,6 +146,22 @@ public class BasketService {
         basketDbService.saveBasket(newBasket);
     }
 
+    private void changeProductCount() {
+
+    }
+
+    public void deleteBasket(OAuth2User oauth, DeleteBasket delete, String type) {
+        Long userId = userDbService.findUserIdByOauth(oauth);
+
+        switch (type) {
+            case "regular":
+                deleteProductInRegular(userId, delete);
+                break;
+            default:
+                deleteProductInBasket(userId, delete);
+        }
+    }
+
     public void deleteProductInBasket(Long userId, DeleteBasket delete) {
         Basket findBasket = basketDbService.ifExistsReturnBasket(userId);
         List<Long> deleteId = delete.getDeleteProductId();
@@ -91,14 +173,34 @@ public class BasketService {
         basketDbService.saveBasket(findBasket);
     }
 
-    public TotalPriceInfo getTotalPriceInfo(Long userId) {
+    public void deleteProductInRegular(Long userId, DeleteBasket delete) {
         Basket findBasket = basketDbService.ifExistsReturnBasket(userId);
+        List<Long> deleteId = delete.getDeleteProductId();
 
-        return TotalPriceInfo.builder()
-                .totalBasketPrice(findBasket.getTotalBasketPrice())
-                .discountedBasketTotalPrice(findBasket.getDiscountedBasketTotalPrice())
-                .discountedBasketPrice(findBasket.getDiscountedBasketPrice())
-                .build();
+        basketDbService.deleteAllByProductBasketId(deleteId);
+
+        calculateRegularTotalPrice(findBasket);
+
+        basketDbService.saveBasket(findBasket);
+    }
+
+    public TotalPriceInfo getTotalPriceInfo(OAuth2User oauth, String type) {
+        Basket findBasket = basketDbService.ifExistsReturnBasket(userDbService.findUserIdByOauth(oauth));
+
+        switch (type) {
+            case "regular":
+                return TotalPriceInfo.builder()
+                        .totalBasketPrice(findBasket.getTotalRegularPrice())
+                        .discountedBasketTotalPrice(findBasket.getDiscountedRegularTotalPrice())
+                        .discountedBasketPrice(findBasket.getDiscountedRegularPrice())
+                        .build();
+            default:
+                return TotalPriceInfo.builder()
+                        .totalBasketPrice(findBasket.getTotalBasketPrice())
+                        .discountedBasketTotalPrice(findBasket.getDiscountedBasketTotalPrice())
+                        .discountedBasketPrice(findBasket.getDiscountedBasketPrice())
+                        .build();
+        }
     }
 
     private void calculateTotalPrice(Basket basket) {
@@ -107,5 +209,24 @@ public class BasketService {
         Integer discountedBasketPrice = totalBasketPrice - discountedTotalPrice;
 
         basket.setBasketPrice(totalBasketPrice, discountedTotalPrice, discountedBasketPrice);
+    }
+
+    private void calculateRegularTotalPrice(Basket basket) {
+        Integer totalRegularPrice = basketDbService.getTotalRegularPrice(basket.getBasketId());
+        Integer discountedRegularTotalPrice = basketDbService.getDiscountedTotalRegularPrice(basket.getBasketId());
+        Integer discountedRegularPrice = totalRegularPrice - discountedRegularTotalPrice;
+
+        basket.setRegularPrice(totalRegularPrice, discountedRegularTotalPrice, discountedRegularPrice);
+    }
+
+    public Page<GetBasket> getBasketList(OAuth2User oauth, Pageable pageable, String type) {
+        Long userId = userDbService.findUserIdByOauth(oauth);
+
+        switch (type) {
+            case "regular":
+                return basketDbService.getRegularList(userId, pageable);
+            default:
+                return basketDbService.getBasketList(userId, pageable);
+        }
     }
 }

--- a/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/delivery/controller/DeliveryController.java
+++ b/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/delivery/controller/DeliveryController.java
@@ -1,0 +1,11 @@
+package com.sidenow.freshgreenish.domain.delivery.controller;
+
+import com.sidenow.freshgreenish.domain.delivery.service.DeliverService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class DeliveryController {
+    private final DeliverService deliverService;
+}

--- a/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/delivery/entity/Delivery.java
+++ b/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/delivery/entity/Delivery.java
@@ -1,42 +1,75 @@
 package com.sidenow.freshgreenish.domain.delivery.entity;
 
-import com.sidenow.freshgreenish.domain.purchase.entity.Purchase;
-import com.sidenow.freshgreenish.global.utils.Auditable;
+import com.sidenow.freshgreenish.domain.address.entity.Address;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import org.hibernate.annotations.SQLDelete;
-import org.hibernate.annotations.Where;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@SQLDelete(sql = "UPDATE delivery SET deleted = true WHERE id = ?")
-@Where(clause = "deleted = false")
-public class Delivery extends Auditable {
+public class Delivery{
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "PAYMENT_INFO_ID")
+    @Column(name = "DELIVERY_ID")
     private Long deliveryId;
+    private Long purchaseId;
+    private Long userId;
 
-    private LocalDateTime paymentDate;
-
-    private Boolean isRegular;
-
+    @Column(updatable = false)
+    private LocalDateTime firstPaymentDate;
+    @Setter
+    private LocalDateTime thisMonthPaymentDate;
+    @Setter
+    private LocalDateTime nextPaymentDate;
+    @Setter
     private LocalDateTime deliveryDate;
 
-    @OneToOne
-    private Purchase purchase;
+    private Boolean isRegular;
+    private String paymentMethod;
+
+    private Integer postalCode;
+    private String addressMain;
+    private String addressDetail;
+    private String addressNickname;
+    private Boolean isDefaultAddress;
+    private String recipientName;
+    private String phoneNumber;
 
     @Builder
-    public Delivery(LocalDateTime paymentDate, Boolean isRegular, LocalDateTime deliveryDate, Purchase purchase) {
-        this.paymentDate = paymentDate;
+    public Delivery(Long deliveryId, Long purchaseId, Long userId, LocalDateTime firstPaymentDate,
+                    LocalDateTime thisMonthPaymentDate, LocalDateTime nextPaymentDate, Boolean isRegular,
+                    LocalDateTime deliveryDate, Integer postalCode, String addressMain, String addressDetail,
+                    String addressNickname, Boolean isDefaultAddress, String recipientName,
+                    String phoneNumber, String paymentMethod) {
+        this.deliveryId = deliveryId;
+        this.purchaseId = purchaseId;
+        this.userId = userId;
+        this.firstPaymentDate = firstPaymentDate;
+        this.thisMonthPaymentDate = thisMonthPaymentDate;
+        this.nextPaymentDate = nextPaymentDate;
         this.isRegular = isRegular;
         this.deliveryDate = deliveryDate;
-        this.purchase = purchase;
+        this.postalCode = postalCode;
+        this.addressMain = addressMain;
+        this.addressDetail = addressDetail;
+        this.addressNickname = addressNickname;
+        this.isDefaultAddress = isDefaultAddress;
+        this.recipientName = recipientName;
+        this.phoneNumber = phoneNumber;
+        this.paymentMethod = paymentMethod;
     }
+
+    public void setAddressInfo(Address address) {
+        this.postalCode = address.getPostalCode();
+        this.addressMain = address.getAddressMain();
+        this.addressDetail = address.getAddressDetail();
+        this.addressNickname = address.getAddressNickname();
+        this.isDefaultAddress = address.getIsDefaultAddress();
+        this.phoneNumber = address.getPhoneNumber();
+        this.recipientName = address.getRecipientName();
+    }
+
+
 }

--- a/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/delivery/repository/DeliveryRepository.java
+++ b/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/delivery/repository/DeliveryRepository.java
@@ -1,0 +1,10 @@
+package com.sidenow.freshgreenish.domain.delivery.repository;
+
+import com.sidenow.freshgreenish.domain.delivery.entity.Delivery;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface DeliveryRepository extends JpaRepository<Delivery, Long> {
+    Optional<Delivery> findByPurchaseId(Long purchaseId);
+}

--- a/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/delivery/service/DeliverService.java
+++ b/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/delivery/service/DeliverService.java
@@ -1,0 +1,15 @@
+package com.sidenow.freshgreenish.domain.delivery.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DeliverService {
+    private final DeliveryDbService deliveryDbService;
+
+
+
+}

--- a/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/delivery/service/DeliveryDbService.java
+++ b/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/delivery/service/DeliveryDbService.java
@@ -1,0 +1,49 @@
+package com.sidenow.freshgreenish.domain.delivery.service;
+
+import com.sidenow.freshgreenish.domain.address.entity.Address;
+import com.sidenow.freshgreenish.domain.delivery.entity.Delivery;
+import com.sidenow.freshgreenish.domain.delivery.repository.DeliveryRepository;
+import com.sidenow.freshgreenish.global.exception.BusinessLogicException;
+import com.sidenow.freshgreenish.global.exception.ExceptionCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class DeliveryDbService {
+    private final DeliveryRepository deliveryRepository;
+
+    public void saveDelivery(Delivery delivery) {
+        deliveryRepository.save(delivery);
+    }
+
+    public Delivery saveAndReturnDelivery(Delivery delivery) {
+        return deliveryRepository.save(delivery);
+    }
+
+    public Delivery ifExistsReturnDelivery(Long purchaseId) {
+        return deliveryRepository.findByPurchaseId(purchaseId)
+                .orElseThrow(() -> new BusinessLogicException(ExceptionCode.DELIVERY_NOT_FOUND));
+    }
+
+    public Delivery findOrCreateDelivery(Long purchaseId, Long userId, LocalDateTime paymentDate, String method, Address address) {
+        if (deliveryRepository.findByPurchaseId(purchaseId).isPresent()) {
+            return deliveryRepository.findByPurchaseId(purchaseId).get();
+        }
+
+        Delivery delivery =  Delivery.builder()
+                .purchaseId(purchaseId)
+                .userId(userId)
+                .firstPaymentDate(paymentDate)
+                .isRegular(true)
+                .paymentMethod(method)
+                .build();
+
+        delivery.setAddressInfo(address);
+        Delivery newDelivery = saveAndReturnDelivery(delivery);
+
+        return newDelivery;
+    }
+}

--- a/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/payment/controller/PaymentController.java
+++ b/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/payment/controller/PaymentController.java
@@ -33,6 +33,14 @@ public class PaymentController {
         return ResponseEntity.ok().body(message);
     }
 
+    // kakao 정기 결제 요청
+    @GetMapping("/purchase/{purchaseId}/subscription/kakao/payment")
+    public ResponseEntity<Message<?>> orderKakaoRegularPayment(@PathVariable("purchaseId") Long purchaseId) {
+        Message<?> message = paymentService.getKakaoSubUrl(purchaseId);
+        if (message.getData() == null) paymentService.getFailedPayMessage();
+        return ResponseEntity.ok().body(message);
+    }
+
     // Toss 결제 성공
     @GetMapping("/api/purchase/{purchaseId}/toss/success")
     public ResponseEntity<Message<?>> successTossPayment(@PathVariable("purchaseId") Long purchaseId) {
@@ -50,6 +58,15 @@ public class PaymentController {
         return ResponseEntity.ok().build();
     }
 
+    // kakao 정기 결제 성공
+    @GetMapping("/api/purchase/{purchaseId}/subscription/kakao/success")
+    public ResponseEntity<Message<?>> successKakaoRegularPayment(@PathVariable("purchaseId") Long purchaseId,
+                                                                 @RequestParam("pg_token") String pgToken) {
+        Message<?> message = paymentService.getSuccessKakaoRegularPaymentInfo(purchaseId, pgToken);
+        if (message.getData() == null) paymentService.getFailedPayMessage();
+        return ResponseEntity.ok().build();
+    }
+
     // Toss 결제 실패
     @GetMapping("/api/purchase/{purchaseId}/toss/failure")
     public ResponseEntity<String> failedTossPayment(@PathVariable("purchaseId") Long purchaseId) {
@@ -60,6 +77,14 @@ public class PaymentController {
     @GetMapping("/api/purchase/{purchaseId}/kakao/cancellation")
     public ResponseEntity<String> cancelKakaoPayment(@PathVariable("purchaseId") Long purchaseId) {
         return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).body(CANCELED_PAY_MESSAGE);
+    }
+
+    // kakao 정기 결제 취소(비활성화)
+    @GetMapping("/purchase/{purchaseId}/subscription/kakao/cancellation")
+    public ResponseEntity<String> cancelKakaoRegularPayment(@PathVariable("purchaseId") Long purchaseId) {
+        Message<?> message = paymentService.cancleKakaoRegularPayment(purchaseId);
+        if (message.getData() == null) paymentService.getFailedPayMessage();
+        return ResponseEntity.ok().build();
     }
 
     // kakao 결제 실패

--- a/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/payment/entity/PaymentInfo.java
+++ b/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/payment/entity/PaymentInfo.java
@@ -7,6 +7,8 @@ import com.sidenow.freshgreenish.domain.purchase.entity.Purchase;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -16,12 +18,18 @@ public class PaymentInfo {
     @Column(name = "PAYMENT_ID")
     private Long paymentId;
 
+    @Setter
+    @Column(updatable = false)
+    private LocalDateTime paymentDate;
+    @Setter
+    private LocalDateTime deliveryDate;
     private Integer quantity = 0;
 
     /* ---------- 카카오 ---------- */
 
     private String cid;
     private String tid;
+    private String sid;
     private String partnerOrderId;
     private String partnerUserId;
     private String itemName;
@@ -51,8 +59,9 @@ public class PaymentInfo {
     private Purchase purchase;
 
     @Builder
-    public PaymentInfo(Purchase purchase) {
+    public PaymentInfo(Purchase purchase, String orderName) {
         this.purchase = purchase;
+        this.orderName = orderName;
     }
 
     public void setPurchase(Purchase purchase) {
@@ -61,6 +70,9 @@ public class PaymentInfo {
 
     public void setPaymentKey(String paymentKey) {
         this.paymentKey = paymentKey;
+    }
+    public void setSid(String sid) {
+        this.sid = sid;
     }
 
     public void setTossPaymentInfo(ReadyToTossPayInfo body) {

--- a/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/payment/feign/KakaoPayFeignClient.java
+++ b/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/payment/feign/KakaoPayFeignClient.java
@@ -16,15 +16,26 @@ public interface KakaoPayFeignClient {
                                       @SpringQueryMap ReadyToKakaoPayInfo params);
 
     @PostMapping(value = "/v1/payment/approve")
-    KakaoPaySuccessInfo successForPayment(
-            @RequestHeader(PayConstants.AUTHORIZATION) String authorization,
-            @RequestHeader(PayConstants.ACCEPT) String accept,
-            @RequestHeader(PayConstants.CONTENT_TYPE) String contentType,
-            @SpringQueryMap RequestForKakaoPayInfo query);
+    KakaoPaySuccessInfo successForPayment(@RequestHeader(PayConstants.AUTHORIZATION) String authorization,
+                                          @RequestHeader(PayConstants.ACCEPT) String accept,
+                                          @RequestHeader(PayConstants.CONTENT_TYPE) String contentType,
+                                          @SpringQueryMap RequestForKakaoPayInfo query);
 
     @PostMapping(value = "/v1/payment/cancel")
     KakaoPayCancelInfo cancelForPayment(@RequestHeader(PayConstants.AUTHORIZATION) String authorization,
                                         @RequestHeader(PayConstants.ACCEPT) String accept,
                                         @RequestHeader(PayConstants.CONTENT_TYPE) String contentType,
                                         @SpringQueryMap RequestForKakaoPayCancelInfo params);
+
+    @PostMapping(value = "/v1/payment/subscription")
+    KakaoSubReadyInfo readyForSubscription(@RequestHeader(PayConstants.AUTHORIZATION) String authorization,
+                                           @RequestHeader(PayConstants.ACCEPT) String accept,
+                                           @RequestHeader(PayConstants.CONTENT_TYPE) String contentType,
+                                           @SpringQueryMap ReadyToKakaoSubInfo params);
+
+    @PostMapping(value = "/v1/payment/manage/subscription/inactive")
+    KakaoPayRegularCancelInfo cancelForSubscription(@RequestHeader(PayConstants.AUTHORIZATION) String authorization,
+                                                    @RequestHeader(PayConstants.ACCEPT) String accept,
+                                                    @RequestHeader(PayConstants.CONTENT_TYPE) String contentType,
+                                                    @SpringQueryMap RequestForKakaoRegularPayCancel params);
 }

--- a/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/payment/kakao/KakaoPayRegularCancelInfo.java
+++ b/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/payment/kakao/KakaoPayRegularCancelInfo.java
@@ -1,0 +1,29 @@
+package com.sidenow.freshgreenish.domain.payment.kakao;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class KakaoPayRegularCancelInfo {
+    private String cid;
+    private String sid;
+    private String status;
+    private Date createdAt;
+    private Date last_approved_at;
+    private Date inactivated_at;
+    private String orderStatus;
+
+    public void setOrderStatus(String orderStatus) {
+        this.orderStatus = orderStatus;
+    }
+}

--- a/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/payment/kakao/KakaoSubReadyInfo.java
+++ b/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/payment/kakao/KakaoSubReadyInfo.java
@@ -1,0 +1,32 @@
+package com.sidenow.freshgreenish.domain.payment.kakao;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class KakaoSubReadyInfo {
+    private String aid;
+    private String cid;
+    private String sid;
+    private String partner_order_id;
+    private String partner_user_id;
+    private String payment_method_type;
+    private Amount amount;
+    private KakaoCard card_info;
+    private String item_name;
+    private String item_code;
+    private String quantity;
+    private Date created_at;
+    private Date approved_at;
+    private String payload;
+}

--- a/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/payment/kakao/ReadyToKakaoSubInfo.java
+++ b/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/payment/kakao/ReadyToKakaoSubInfo.java
@@ -9,20 +9,14 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class ReadyToKakaoPayInfo {
+public class ReadyToKakaoSubInfo {
     private String cid;
+    private String sid;
     private String partner_order_id;
     private String partner_user_id;
     private String item_name;
+    private String item_code;
     private Integer quantity;
     private Integer total_amount;
-    private Integer val_amount;
     private Integer tax_free_amount;
-    private String approval_url;
-    private String fail_url;
-    private String cancel_url;
-
-    public void setCid(String cid) {
-        this.cid = cid;
-    }
 }

--- a/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/payment/kakao/RequestForKakaoRegularPayCancel.java
+++ b/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/payment/kakao/RequestForKakaoRegularPayCancel.java
@@ -1,0 +1,15 @@
+package com.sidenow.freshgreenish.domain.payment.kakao;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RequestForKakaoRegularPayCancel {
+    private String cid;
+    private String sid;
+}

--- a/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/product/repository/CustomProductRepository.java
+++ b/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/product/repository/CustomProductRepository.java
@@ -19,4 +19,6 @@ public interface CustomProductRepository {
     Integer getPrice(Long productId);
     Integer getDiscountPrice(Long productId);
 
+    String getProductTitle(Long purchaseId);
+
 }

--- a/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/product/repository/ProductRepositoryImpl.java
+++ b/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/product/repository/ProductRepositoryImpl.java
@@ -17,6 +17,7 @@ import java.util.List;
 
 import static com.sidenow.freshgreenish.domain.likes.entity.QLikes.likes;
 import static com.sidenow.freshgreenish.domain.product.entity.QProduct.product;
+import static com.sidenow.freshgreenish.domain.purchase.entity.QPurchase.purchase;
 
 @Repository
 public class ProductRepositoryImpl implements CustomProductRepository {
@@ -173,10 +174,21 @@ public class ProductRepositoryImpl implements CustomProductRepository {
                 .fetchOne();
     }
 
+    @Override
+    public String getProductTitle(Long purchaseId) {
+        return queryFactory
+                .select(product.title)
+                .from(product)
+                .leftJoin(purchase).on(purchase.productId.eq(product.productId))
+                .where(purchase.purchaseId.eq(purchaseId))
+                .fetchOne();
+    }
+
     private JPQLQuery<Boolean> isLikes(NumberPath<Long> productId, Long userId) {
         return JPAExpressions.select(
                         new CaseBuilder()
                                 .when(likes.isNotNull()).then(true)
+                                .when(likes.isNull()).then(false)
                                 .otherwise(false)
                 ).from(likes)
                 .where(likes.productId.eq(productId).and(likes.userId.eq(userId)));

--- a/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/product/service/ProductDbService.java
+++ b/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/product/service/ProductDbService.java
@@ -87,4 +87,8 @@ public class ProductDbService {
     public User findUser(OAuth2User oauth) {
         return userDbService.findUserByEmail(oauth);
     }
+
+    public String getProductTitle(Long purchaseId) {
+        return productRepository.getProductTitle(purchaseId);
+    }
 }

--- a/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/purchase/controller/PurchaseController.java
+++ b/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/purchase/controller/PurchaseController.java
@@ -60,6 +60,30 @@ public class PurchaseController {
                 .body(new WrapPurchaseInfo<>(purchase.getOrderLists(), purchase.getAddressInfo(), purchase.getPriceInfo()));
     }
 
+    // 장바구니 - 선택 정기 결제
+    @PostMapping("/purchase/subscription/basket/select")
+    public ResponseEntity createRegularPurchaseSelect(@RequestBody @Valid PostSelectPurchase post,
+                                                      @AuthenticationPrincipal OAuth2User oauth) {
+        purchaseService.createRegularPurchaseSelect(oauth, post);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    // 장바구니 - 전체 정기 결제
+    @PostMapping("/purchase/subscription/basket/all")
+    public ResponseEntity createRegularPurchaseAll(@AuthenticationPrincipal OAuth2User oauth) {
+        purchaseService.createRegularPurchaseAll(oauth);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    // 장바구니 - 정기 결제 요청 페이지
+    @GetMapping("/purchase/{purchaseId}/subscription/basket/payment")
+    public ResponseEntity getRegularPurchase(@PathVariable("purchaseId") Long purchaseId,
+                                             @AuthenticationPrincipal OAuth2User oauth) {
+        GetPurchaseInfo purchase = purchaseService.getRegularPurchaseInfo(purchaseId, oauth);
+        return ResponseEntity.ok()
+                .body(new WrapPurchaseInfo<>(purchase.getOrderLists(), purchase.getAddressInfo(), purchase.getPriceInfo()));
+    }
+
     @PatchMapping("/purchase/{purchaseId}")
     public ResponseEntity usedPointInPurchase(@PathVariable("purchaseId") Long purchaseId,
                                               @RequestBody @Valid PostUsePoint post,
@@ -75,6 +99,15 @@ public class PurchaseController {
         return ResponseEntity.ok().build();
     }
 
+    @PatchMapping("/master/purchase/{purchaseId}/{statusId}")
+    public ResponseEntity masterChangePurchaseStatus(@PathVariable("purchaseId") Long purchaseId,
+                                                     @PathVariable("statusId") Integer statusId,
+                                                     @AuthenticationPrincipal OAuth2User oauth) {
+        purchaseService.masterChangePurchaseStatus(purchaseId, oauth, statusId);
+        return ResponseEntity.ok().build();
+    }
+
+    // 마이페이지 주문 내역
     @GetMapping("/purchase")
     public ResponseEntity getPurchaseOnMyPage(@AuthenticationPrincipal OAuth2User oauth,
                                               Pageable pageable) {
@@ -82,10 +115,18 @@ public class PurchaseController {
         return ResponseEntity.ok().body(new MultiResponseDto<>(purchase));
     }
 
+    // 마이페이지 정기결제 내역
+    @GetMapping("/purchase/subscription")
+    public ResponseEntity getSubscriptionOnMyPage(@AuthenticationPrincipal OAuth2User oauth,
+                                                  Pageable pageable) {
+        Page<GetSubscriptionOnMyPage> purchase = purchaseService.getSubscriptionOnMyPage(oauth, pageable);
+        return ResponseEntity.ok().body(new MultiResponseDto<>(purchase));
+    }
+
     @GetMapping("/purchase/{purchaseId}")
     public ResponseEntity getPurchaseDetail(@PathVariable("purchaseId") Long purchaseId,
                                               @AuthenticationPrincipal OAuth2User oauth) {
-        GetPurchaseInfo purchase = purchaseService.getPurchaseInfo(purchaseId, oauth);
+        GetPurchaseDetail purchase = purchaseService.getPurchaseDetail(purchaseId, oauth);
         return ResponseEntity.ok()
                 .body(new WrapPurchaseInfo<>(purchase.getOrderLists(), purchase.getAddressInfo(), purchase.getPriceInfo()));
     }

--- a/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/purchase/dto/AddressInfo.java
+++ b/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/purchase/dto/AddressInfo.java
@@ -9,6 +9,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 public class AddressInfo {
+    private Long addressId;
     private Integer postalCode;
     private String addressMain;
     private String addressDetail;
@@ -21,6 +22,7 @@ public class AddressInfo {
     @Builder
     @QueryProjection
     public AddressInfo(Address address) {
+        this.addressId = address.getAddressId();
         this.postalCode = address.getPostalCode();
         this.addressMain = address.getAddressMain();
         this.addressDetail = address.getAddressDetail();

--- a/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/purchase/dto/GetPurchaseDetail.java
+++ b/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/purchase/dto/GetPurchaseDetail.java
@@ -1,0 +1,22 @@
+package com.sidenow.freshgreenish.domain.purchase.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class GetPurchaseDetail {
+    List<OrderList> orderLists;
+    AddressInfo addressInfo;
+    PriceInfo priceInfo;
+
+    @Builder
+    public GetPurchaseDetail(List<OrderList> orderLists, AddressInfo addressInfo, PriceInfo priceInfo) {
+        this.orderLists = orderLists;
+        this.addressInfo = addressInfo;
+        this.priceInfo = priceInfo;
+    }
+}

--- a/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/purchase/dto/GetSubscriptionOnMyPage.java
+++ b/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/purchase/dto/GetSubscriptionOnMyPage.java
@@ -1,0 +1,82 @@
+package com.sidenow.freshgreenish.domain.purchase.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import com.sidenow.freshgreenish.domain.address.entity.Address;
+import com.sidenow.freshgreenish.domain.purchase.entity.Purchase;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+public class GetSubscriptionOnMyPage {
+    private Long purchaseId;
+    private Long deliveryId;
+    private String purchaseNumber;
+    private String orderName;
+    private Integer usedPoints;
+    private Integer totalPrice;
+    private String purchaseStatus;
+
+    private LocalDateTime firstPaymentDate;
+    private LocalDateTime thisMonthPaymentDate;
+    private LocalDateTime nextPaymentDate;
+    private LocalDateTime deliveryDate;
+
+    private Boolean isRegular;
+    private String paymentMethod;
+
+    private Integer postalCode;
+    private String addressMain;
+    private String addressDetail;
+    private String addressNickname;
+    private Boolean isInMyPage;
+    private Boolean isDefaultAddress;
+    private String recipientName;
+    private String phoneNumber;
+
+    private Long productId;
+    private String title;
+    private String productFirstImage;
+    private Integer count;
+    private Integer discountedPrice;
+
+    @Builder
+    @QueryProjection
+    public GetSubscriptionOnMyPage(Purchase purchase, String orderName, Address address, String title,
+                                   String productFirstImage, Integer discountedPrice, Long productId,
+                                   Long deliveryId, LocalDateTime deliveryDate, LocalDateTime firstPaymentDate,
+                                   LocalDateTime thisMonthPaymentDate, LocalDateTime nextPaymentDate) {
+        this.purchaseId = purchase.getPurchaseId();
+        this.deliveryId = deliveryId;
+
+        this.purchaseNumber = purchase.getPurchaseNumber();
+        this.orderName = orderName;
+        this.usedPoints = purchase.getUsedPoints();
+        this.totalPrice = purchase.getTotalPrice();
+
+        this.deliveryDate = deliveryDate;
+        this.firstPaymentDate = firstPaymentDate;
+        this.thisMonthPaymentDate = thisMonthPaymentDate;
+        this.nextPaymentDate = nextPaymentDate;
+        this.paymentMethod = purchase.getPaymentMethod();
+
+        this.postalCode = address.getPostalCode();
+        this.addressMain = address.getAddressMain();
+        this.addressDetail = address.getAddressDetail();
+        this.addressNickname = address.getAddressNickname();
+        this.isInMyPage = address.getIsInMyPage();
+        this.isDefaultAddress = address.getIsDefaultAddress();
+        this.recipientName = address.getRecipientName();
+        this.phoneNumber = address.getPhoneNumber();
+        this.productId = productId;
+        this.title = title;
+        this.productFirstImage = productFirstImage;
+        this.count = purchase.getCount();
+        this.discountedPrice = discountedPrice;
+        this.purchaseStatus = purchase.getPurchaseStatus().getStatus();
+    }
+}

--- a/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/purchase/entity/Purchase.java
+++ b/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/purchase/entity/Purchase.java
@@ -22,6 +22,7 @@ public class Purchase extends Auditable {
     @Column(name = "PURCHASE_ID")
     private Long purchaseId;
     private Long userId;
+    private Long deliveryId;
 
     @Setter
     private Long addressId;
@@ -64,12 +65,13 @@ public class Purchase extends Auditable {
     private List<ProductPurchase> productPurchase = new ArrayList<>();
 
     @Builder
-    public Purchase(Long purchaseId, Long basketId, Long userId, Long addressId, Long productId,
+    public Purchase(Long purchaseId, Long basketId, Long userId, Long deliveryId, Long addressId, Long productId,
                     Integer count, Integer totalCount, Integer totalPrice, Boolean isRegularDelivery,
                     Integer totalPriceBeforeUsePoint, Integer usedPoints) {
         this.purchaseId = purchaseId;
         this.basketId = basketId;
         this.userId = userId;
+        this.deliveryId = deliveryId;
         this.addressId = addressId;
         this.productId = productId;
         this.count = count;

--- a/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/purchase/repository/CustomPurchaseRepository.java
+++ b/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/purchase/repository/CustomPurchaseRepository.java
@@ -1,10 +1,7 @@
 package com.sidenow.freshgreenish.domain.purchase.repository;
 
 import com.sidenow.freshgreenish.domain.product.entity.Product;
-import com.sidenow.freshgreenish.domain.purchase.dto.AddressInfo;
-import com.sidenow.freshgreenish.domain.purchase.dto.GetPurchaseOnMyPage;
-import com.sidenow.freshgreenish.domain.purchase.dto.OrderList;
-import com.sidenow.freshgreenish.domain.purchase.dto.PriceInfo;
+import com.sidenow.freshgreenish.domain.purchase.dto.*;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -13,7 +10,10 @@ import java.util.List;
 public interface CustomPurchaseRepository {
     List<OrderList> getOrderListByPurchaseIdAndUserId(Long purchaseId, Long userId);
     List<OrderList> getBasketOrderList(Long basketId, Long purchaseId, Long userId);
+    List<OrderList> getRegularOrderList(Long basketId, Long purchaseId, Long userId);
+
     Page<GetPurchaseOnMyPage> getPurchaseOnMyPage(Long userId, Pageable pageable);
+    Page<GetSubscriptionOnMyPage> getSubscriptionOnMyPage(Long userId, Pageable pageable);
 
     List<Product> getProductIdList(Long purchaseId, Long userId);
 

--- a/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/purchase/service/PurchaseDbService.java
+++ b/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/purchase/service/PurchaseDbService.java
@@ -1,10 +1,7 @@
 package com.sidenow.freshgreenish.domain.purchase.service;
 
 import com.sidenow.freshgreenish.domain.product.entity.Product;
-import com.sidenow.freshgreenish.domain.purchase.dto.AddressInfo;
-import com.sidenow.freshgreenish.domain.purchase.dto.GetPurchaseOnMyPage;
-import com.sidenow.freshgreenish.domain.purchase.dto.OrderList;
-import com.sidenow.freshgreenish.domain.purchase.dto.PriceInfo;
+import com.sidenow.freshgreenish.domain.purchase.dto.*;
 import com.sidenow.freshgreenish.domain.purchase.entity.Purchase;
 import com.sidenow.freshgreenish.domain.purchase.repository.PurchaseRepository;
 import com.sidenow.freshgreenish.global.exception.BusinessLogicException;
@@ -42,8 +39,16 @@ public class PurchaseDbService {
         return purchaseRepository.getBasketOrderList(basketId, purchaseId, userId);
     }
 
+    public List<OrderList> getRegularOrderList(Long basketId, Long purchaseId, Long userId) {
+        return purchaseRepository.getRegularOrderList(basketId, purchaseId, userId);
+    }
+
     public Page<GetPurchaseOnMyPage> getPurchaseOnMyPage(Long useId, Pageable pageable) {
         return purchaseRepository.getPurchaseOnMyPage(useId, pageable);
+    }
+
+    public Page<GetSubscriptionOnMyPage> getSubscriptionOnMyPage(Long useId, Pageable pageable) {
+        return purchaseRepository.getSubscriptionOnMyPage(useId, pageable);
     }
 
     public List<Product> getProductIdList(Long purchaseId, Long userId) {

--- a/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/purchase/util/PurchaseConstants.java
+++ b/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/purchase/util/PurchaseConstants.java
@@ -5,6 +5,7 @@ public class PurchaseConstants {
     public static final String FAILED_INFO_MESSAGE = "결제 정보 조회에 실패했습니다.";
     public static final String INVALID_PARAMS = "파라미터를 다시 한번 확인해보세요.";
     public static final String KAKAO_PAY_URI_MSG = "카카오 페이 결제 URL";
+    public static final String SUCCESS_KAKAO_REGULAR_PAY = "카카오 페이 정기 결제 성공";
     public static final String TOSS_PAY_URI_MSG = "토스 페이 결제 URL";
     public static final String INFO_URI_MSG = "결제 정보 조회 목록입니다.";
     public static final String CANCELED_PAY_MESSAGE = "결제를 취소하셨습니다.";

--- a/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/review/repository/ReviewRepositoryImpl.java
+++ b/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/review/repository/ReviewRepositoryImpl.java
@@ -143,6 +143,7 @@ public class ReviewRepositoryImpl implements CustomReviewRepository {
         return JPAExpressions.select(
                         new CaseBuilder()
                                 .when(likes.isNotNull()).then(true)
+                                .when(likes.isNull()).then(false)
                                 .otherwise(false)
                 ).from(likes)
                 .where(likes.productId.eq(productId).and(likes.userId.eq(userId)));

--- a/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/user/service/UserDbService.java
+++ b/freshgreenish/src/main/java/com/sidenow/freshgreenish/domain/user/service/UserDbService.java
@@ -33,4 +33,11 @@ public class UserDbService {
         return userRepository.findByEmail(userEmail)
                 .orElseThrow(NullPointerException::new);
     }
+
+    public Long findUserIdByOauth(OAuth2User oauth) {
+        String userEmail = oauth.getAttribute("email");
+        User findUser = userRepository.findByEmail(userEmail)
+                .orElseThrow(NullPointerException::new);
+        return findUser.getUserId();
+    }
 }

--- a/freshgreenish/src/main/java/com/sidenow/freshgreenish/global/exception/ExceptionCode.java
+++ b/freshgreenish/src/main/java/com/sidenow/freshgreenish/global/exception/ExceptionCode.java
@@ -17,6 +17,7 @@ public enum ExceptionCode {
     PURCHASE_NOT_FOUND(415, "존재하지 않는 구매 정보입니다."),
     PAYMENT_NOT_FOUND(415, "존재하지 않는 결제 정보입니다."),
     BASKET_NOT_FOUND(415, "존재하지 않는 장바구니입니다."),
+    DELIVERY_NOT_FOUND(415, "존재하지 않는 정기 배송 정보입니다."),
 
     UNAUTHORIZED_FOR_UPDATE(403, "수정 권한이 없습니다."),
     UNAUTHORIZED_FOR_DELETE(403, "삭제 권한이 없습니다."),


### PR DESCRIPTION
# Description
정기 결제 기능 구현 및 장바구니 기능 수정, 그외 코드 추가 및 정리

```
요약
1. 카카오페이 정기 결제 기능 구현
2. 장바구니에 정기 결제 상품 추가 기능 구현
3. 기존 코드 정기 결제/일반 결제 분리
4. 정기 결제 Delivery Entity 추가
5. 결제 시 Address 추가 또는 작성하는 API 구현
6. 그 외 코드 및 API 정리, 수정
```

<h4>장바구니 결제 순서</h4>

(상품 등록) - 장바구니 담기 - 구매할 제품 선택 또는 전체 구매 요청 - 구매 페이지 요청 - 주소 입력 - (적립금 사용) - 카카오페이/토스페이 결제 시도 - 결제 - 결제 완료 - 주문 목록 조회

<br/>

이게 맞게 되는 건지는 확실하지는 않은데 일단 동작은 되는 정기 결제 기능 구현했습니다.

<br/>

1. 장바구니 선택 정기 결제
2. 장바구니 전체 정기 결제
3. 정기 결제 비활성화
4. 주문 목록 조회(주문 완료 시 부터 조회 가능)
5. 정기 결제 주문 목록 조회(주문 완료 시 부터 조회 가능)
6. 결제 페이지에서 새로운 주소 입력하는 기능
7. 결제 페이지에서 기존 주소 선택하는 기능

# ETC
추후에 정기 결제 부분은 리팩토링이 필요할 것 같습니다.

<br/>
